### PR TITLE
feat: V4 inline demos, dark nav, durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Skybots – Apple-inspired Landing (Static)
+
 Deployed on GitHub Pages. No build step.
 
 ## Assets
-Place images in `/images/`:
+Place images in `images/`:
 - hero.webp, speed.webp, integrations.webp, dashboard.webp, cta.webp
 
-Place EXACTLY three demos in `/audio/`:
+Place EXACTLY three demos in `audio/`:
 - demo_1.mp3, demo_2.mp3, demo_3.mp3
 
 ## Update the audio list
-Edit `data/audios.json` so it references only those three files.
+Edit `data/audios.json` so it references only those three files. Do not include durations; the site computes true durations from metadata.
 
 ## Dev notes
-- Relative asset paths for GitHub Pages project sites (no leading `/`).
-- Accessibility: visible focus, `prefers-reduced-motion` honored, alt text provided.
-- Performance: explicit `width`/`height` on images, lazy-load non-hero images.
+- **Inline demos**: The three audio demos are embedded as stacked bars in the first light slab, left of the latency image. There is no sticky/floating player.
+- **Navigation**: The sticky top bar is permanently dark and readable on every section.
+- **Copy**: The third feature slab reads “Throughout peak hours, consistent voice…” to reflect the scalability story.
+- **Performance & accessibility**: Relative asset paths (no leading `/`), visible focus rings, `prefers-reduced-motion` honored, explicit `width`/`height` on images.
 
-(Optional) add images/favicon.ico, images/icon-180.png (simple generated if missing).
+(Optional) add `images/favicon.ico`, `images/icon-180.png` (simple generated if missing).

--- a/app.js
+++ b/app.js
@@ -1,119 +1,84 @@
 // Year
 document.getElementById('year').textContent = new Date().getFullYear();
 
-// Nav scroll state is no longer needed (nav is forced dark), but keep hook if used elsewhere.
-const nav = document.querySelector('.nav');
-if (nav) { const s=()=>{}; window.addEventListener('scroll', s); }
+// ---- Inline demos (no sticky player) ----
+const listEl = document.getElementById('audio-list');
 
-// Audio: inline grid (left column in the first light slab)
-const grid = document.getElementById('audio-grid');
-const audio = document.getElementById('audio');
-const playpause = document.getElementById('playpause');
-const nowplaying = document.getElementById('nowplaying');
-const seek = document.getElementById('seekbar');
-const back15 = document.getElementById('back15');
-const fwd15 = document.getElementById('fwd15');
-const speed = document.getElementById('speed');
+function fmt(s){
+  if(!isFinite(s) || s <= 0) return '--:--';
+  const m = Math.floor(s/60);
+  const sec = Math.round(s - m*60);
+  return `${String(m).padStart(2,'0')}:${String(sec).padStart(2,'0')}`;
+}
 
-let list = [];
+// Single shared audio element
+const A = new Audio();
+A.preload = 'metadata';
 let current = -1;
 let seeking = false;
 
-function fmtDuration(s){
-  if(!isFinite(s) || s<=0) return '';
-  const m = Math.floor(s/60);
-  const sec = Math.round(s - m*60);
-  const mm = String(m).padStart(2,'0');
-  const ss = String(sec).padStart(2,'0');
-  return `${mm}:${ss}`;
-}
-function getDuration(url){
-  return new Promise(res=>{
-    const a = new Audio();
-    a.preload = 'metadata';
-    a.src = url;
-    a.addEventListener('loadedmetadata', ()=> res(a.duration));
-    a.addEventListener('error', ()=> res(NaN));
-  });
-}
-
+// Render three stacked demo bars
 fetch('data/audios.json')
-  .then(r => r.json())
-  .then(async (audios) => {
-    list = (audios || []).slice(0,3);
+  .then(r => r.json())
+  .then(async items => {
+    const demos = (items || []).slice(0,3);
 
-    // Render basic cards first (duration placeholder)
-    grid.innerHTML = list.map((a,i)=>`
-      <div class="audio-card card" role="listitem">
-        <h3>${a.title}</h3>
-        <p class="muted" id="dur-${i}">—:—</p>
-        <button data-i="${i}" aria-label="Play ${a.title}">Play demo</button>
-      </div>
-    `).join('');
+    listEl.innerHTML = demos.map((d,i)=>`
+      <div class="demo" role="listitem" data-i="${i}">
+        <button class="play" aria-label="Play ${d.title}" data-i="${i}">▶</button>
+        <h4>${d.title}</h4>
+        <span class="time" id="dur-${i}">--:--</span>
+        <input class="seek" id="seek-${i}" type="range" min="0" max="100" value="0" aria-label="Seek ${d.title}">
+      </div>
+    `).join('');
 
-    // Fill real durations from metadata
-    await Promise.all(list.map(async (a,i)=>{
-      const d = await getDuration(a.url);
-      const el = document.getElementById(`dur-${i}`);
-      if(el) el.textContent = fmtDuration(d);
-    }));
-  })
-  .catch(() => { grid.innerHTML = '<p class="muted">Demos unavailable.</p>'; });
+    // Load real durations
+    await Promise.all(demos.map((d,i)=>new Promise(res=>{
+      const a = new Audio(); a.preload='metadata'; a.src = d.url;
+      a.onloadedmetadata = ()=>{ const el = document.getElementById(`dur-${i}`); if(el) el.textContent = fmt(a.duration); res(); };
+      a.onerror = ()=> res();
+    })));
 
-// Play behavior
-grid.addEventListener('click', e=>{
-  const btn = e.target.closest('button[data-i]');
-  if(!btn) return;
-  playIndex(+btn.dataset.i);
-});
+    // Event: play/pause
+    listEl.addEventListener('click', e=>{
+      const btn = e.target.closest('.play');
+      if(!btn) return;
+      const i = +btn.dataset.i;
+      if(current !== i){ // switch track
+        current = i;
+        A.src = demos[i].url;
+        A.currentTime = 0;
+      }
+      if(A.paused){ A.play().catch(()=>{}); btn.textContent = '⏸'; }
+      else { A.pause(); btn.textContent = '▶'; }
+      // reset other buttons
+      listEl.querySelectorAll('.play').forEach(b=>{ if(+b.dataset.i !== i) b.textContent = '▶'; });
+    });
 
-// Prefetch on hover/touchstart to trim first-play lag
-grid.addEventListener('mouseover', e=>{
-  const btn = e.target.closest('button[data-i]'); if(!btn) return;
-  const {url} = list[+btn.dataset.i] || {};
-  if(url && audio.src!==url){ audio.src = url; }
-});
-grid.addEventListener('touchstart', e=>{
-  const btn = e.target.closest('button[data-i]'); if(!btn) return;
-  const {url} = list[+btn.dataset.i] || {};
-  if(url && audio.src!==url){ audio.src = url; }
-},{passive:true});
+    // Seek bars
+    listEl.addEventListener('input', e=>{
+      const s = e.target.closest('.seek'); if(!s) return;
+      if(current === -1) return;
+      seeking = true;
+    });
+    listEl.addEventListener('change', e=>{
+      const s = e.target.closest('.seek'); if(!s) return;
+      if(current === -1 || !isFinite(A.duration)) return;
+      A.currentTime = (s.value/100) * A.duration;
+      seeking = false;
+    });
 
-function playIndex(i){
-  current = i;
-  const {title,url} = list[i];
-  audio.src = url;
-  audio.playbackRate = parseFloat(speed.value) || 1;
-  audio.play().catch(()=>{});
-  nowplaying.textContent = title;
-  playpause.textContent = '⏸';
-}
+    // Timeupdate -> update current seek
+    A.addEventListener('timeupdate', ()=>{
+      if(seeking || !isFinite(A.duration) || current === -1) return;
+      const val = (A.currentTime/A.duration)*100;
+      const s = document.getElementById(`seek-${current}`);
+      if(s) s.value = val || 0;
+    });
 
-playpause.addEventListener('click', ()=>{
-  if(audio.paused){ audio.play(); playpause.textContent='⏸'; }
-  else { audio.pause(); playpause.textContent='⏯'; }
-});
-back15.addEventListener('click', ()=> audio.currentTime = Math.max(0, audio.currentTime - 15));
-fwd15.addEventListener('click', ()=> audio.currentTime = Math.min(audio.duration || 0, audio.currentTime + 15));
-speed.addEventListener('change', ()=> audio.playbackRate = parseFloat(speed.value));
-
-audio.addEventListener('timeupdate', ()=>{
-  if(seeking || !isFinite(audio.duration)) return;
-  seek.value = (audio.currentTime / audio.duration) * 100 || 0;
-});
-seek.addEventListener('input', ()=> seeking = true);
-seek.addEventListener('change', ()=>{
-  if(isFinite(audio.duration)){
-    audio.currentTime = (seek.value/100) * audio.duration;
-  }
-  seeking = false;
-});
-audio.addEventListener('ended', ()=> { playpause.textContent='⏯'; });
-
-// Media Session
-if ('mediaSession' in navigator){
-  navigator.mediaSession.setActionHandler('play', ()=> audio.play());
-  navigator.mediaSession.setActionHandler('pause', ()=> audio.pause());
-  navigator.mediaSession.setActionHandler('seekbackward', ()=> back15.click());
-  navigator.mediaSession.setActionHandler('seekforward', ()=> fwd15.click());
-}
+    A.addEventListener('ended', ()=>{
+      const btn = listEl.querySelector(`.play[data-i="${current}"]`);
+      if(btn) btn.textContent = '▶';
+    });
+  })
+  .catch(()=>{ listEl.innerHTML = '<p class="muted">Demos unavailable.</p>'; });

--- a/audios.json
+++ b/audios.json
@@ -1,5 +1,5 @@
 [
-  {"title": "Sales Bot — Warm Intro", "url": "audio/demo_1.mp3", "duration": "00:32"},
-  {"title": "Service Bot — Scheduling", "url": "audio/demo_2.mp3", "duration": "00:41"},
-  {"title": "Lead Capture — No Form", "url": "audio/demo_3.mp3", "duration": "00:28"}
+  { "title": "Sales Bot — Warm Intro", "url": "audio/demo_1.mp3" },
+  { "title": "Service Bot — Scheduling", "url": "audio/demo_2.mp3" },
+  { "title": "Lead Capture — No Form", "url": "audio/demo_3.mp3" }
 ]

--- a/index.html
+++ b/index.html
@@ -1,216 +1,201 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Skybots – AI Voice Bots</title>
-  <meta name="description" content="Skybots voice bots: answer, qualify, schedule, and hand-off—24/7, on-brand." />
-  <link rel="icon" href="images/favicon.ico">
-  <link rel="apple-touch-icon" sizes="180x180" href="images/icon-180.png">
-  <meta name="theme-color" content="#000000">
-  <meta property="og:title" content="Skybots – AI Voice Bots">
-  <meta property="og:description" content="Answer. Qualify. Schedule. Close. Your 24/7 digital rep.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://gonia25.github.io/skybots-apple-style-landing/">
-  <meta property="og:image" content="https://gonia25.github.io/skybots-apple-style-landing/images/hero.webp">
-  <meta name="twitter:card" content="summary_large_image">
-  <link rel="preload" href="images/hero.webp" as="image" fetchpriority="high">
-  <link rel="stylesheet" href="styles.css" />
-  <script defer src="app.js"></script>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Skybots – AI Voice Bots</title>
+  <meta name="description" content="Skybots voice bots: answer, qualify, schedule, and hand-off—24/7, on-brand." />
+  <link rel="icon" href="images/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/icon-180.png">
+  <meta name="theme-color" content="#000000">
+  <meta property="og:title" content="Skybots – AI Voice Bots">
+  <meta property="og:description" content="Answer. Qualify. Schedule. Close. Your 24/7 digital rep.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://gonia25.github.io/skybots-apple-style-landing/">
+  <meta property="og:image" content="https://gonia25.github.io/skybots-apple-style-landing/images/hero.webp">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preload" href="images/hero.webp" as="image" fetchpriority="high">
+  <link rel="stylesheet" href="styles.css" />
+  <script defer src="app.js"></script>
 </head>
 <body>
-  <!-- Sticky translucent nav (always dark) -->
-  <header class="nav" data-scroll>
-    <a class="brand" href="#">Skybots</a>
-    <nav class="nav-links">
-      <a href="#demos-inline">Audio Demos</a>
-      <a href="#features">Features</a>
-      <a href="#plans">Plans</a>
-      <a class="cta" href="#contact">Talk to Sales</a>
-    </nav>
-  </header>
+  <!-- Always-dark sticky nav -->
+  <header class="nav">
+    <a class="brand" href="#">Skybots</a>
+    <nav class="nav-links">
+      <a href="#demos-inline">Audio Demos</a>
+      <a href="#features">Features</a>
+      <a href="#plans">Plans</a>
+      <a class="cta" href="#contact">Talk to Sales</a>
+    </nav>
+  </header>
 
-  <main>
-    <!-- HERO -->
-    <section class="section dark hero" aria-labelledby="hero-title">
-      <div class="container hero-grid">
-        <div class="hero-copy">
-          <h1 id="hero-title">A highly intelligent<br>voice bot—family-friendly fast.</h1>
-          <p class="hero-sub">Answer. Qualify. Schedule. Close. Your 24/7 digital rep.</p>
-          <div class="hero-cta">
-            <a class="btn primary" href="#demos-inline">Listen to demos</a>
-            <a class="btn ghost" href="#demos-inline">See how it works</a>
-          </div>
-        </div>
-        <figure class="hero-media">
-          <img src="images/hero.webp"
-               alt="Youthful friendly service robot presenting an audio waveform."
-               width="1600" height="900" decoding="async">
-        </figure>
-      </div>
-    </section>
+  <main>
+    <!-- HERO -->
+    <section class="section dark hero" aria-labelledby="hero-title">
+      <div class="container hero-grid">
+        <div class="hero-copy">
+          <h1 id="hero-title">A highly intelligent<br>voice bot—family-friendly fast.</h1>
+          <p class="hero-sub">Answer. Qualify. Schedule. Close. Your 24/7 digital rep.</p>
+          <div class="hero-cta">
+            <a class="btn primary" href="#demos-inline">Listen to demos</a>
+            <a class="btn ghost" href="#demos-inline">See how it works</a>
+          </div>
+        </div>
+        <figure class="hero-media">
+          <img src="images/hero.webp" alt="Youthful friendly service robot presenting an audio waveform."
+               width="1600" height="900" decoding="async">
+        </figure>
+      </div>
+    </section>
 
-    <!-- FEATURES: Slab #1 (light) WITH INLINE DEMOS ON THE LEFT -->
-    <section id="features" class="section light" aria-label="Highlights">
-      <div class="container panel">
-        <div class="copy">
-          <h2>Natural. Fast. On-brand.</h2>
-          <p>Latency-tuned speech with calm, human-like pacing and your exact tone.</p>
+    <!-- FEATURES: Slab #1 (light) — demos embedded on the left -->
+    <section id="features" class="section light" aria-label="Highlights">
+      <div class="container panel">
+        <div class="copy">
+          <h2>Natural. Fast. On-brand.</h2>
+          <p>Latency-tuned speech with calm, human-like pacing and your exact tone.</p>
 
-          <!-- Inline demos (top of site) -->
-          <div id="demos-inline" class="demos-inline" aria-label="Audio demos">
-            <h3 class="demos-title">Audio demos</h3>
-            <div id="audio-grid" class="audio-grid inline" role="list" aria-describedby="demos-inline">
-              <!-- JS will inject three cards here -->
-              <div class="skeleton card"></div>
-              <div class="skeleton card"></div>
-              <div class="skeleton card"></div>
-            </div>
-          </div>
-        </div>
+          <!-- Inline demos block -->
+          <div id="demos-inline" class="demos-inline" aria-label="Audio demos">
+            <h3 class="demos-title">Audio demos</h3>
+            <div id="audio-list" class="demo-list" role="list" aria-describedby="demos-inline">
+              <!-- JS injects three stacked demo bars here -->
+              <div class="skeleton bar"></div>
+              <div class="skeleton bar"></div>
+              <div class="skeleton bar"></div>
+            </div>
+          </div>
+        </div>
 
-        <img src="images/speed.webp"
-             alt="Robot hand indicating a glass tile with ultra-low latency waveform."
-             width="1600" height="1066" loading="lazy" decoding="async">
-      </div>
-    </section>
+        <img src="images/speed.webp"
+             alt="Robot hand indicating a glass tile with ultra-low latency waveform."
+             width="1600" height="1066" loading="lazy" decoding="async">
+      </div>
+    </section>
 
-    <!-- FEATURES: Slab #2 (dark) -->
-    <section class="section dark">
-      <div class="container panel">
-        <div class="copy">
-          <h2>Plugs into anything.</h2>
-          <p>Calendars, CRMs, forms, spreadsheets, webhooks, analytics—no human routing.</p>
-        </div>
-        <img src="images/integrations.webp"
-             alt="Friendly robot surrounded by neutral system glyphs for integrations."
-             width="1600" height="1066" loading="lazy" decoding="async">
-      </div>
-    </section>
+    <!-- FEATURES: Slab #2 (dark) -->
+    <section class="section dark">
+      <div class="container panel">
+        <div class="copy">
+          <h2>Plugs into anything.</h2>
+          <p>Calendars, CRMs, forms, spreadsheets, webhooks, analytics—no human routing.</p>
+        </div>
+        <img src="images/integrations.webp"
+             alt="Friendly robot surrounded by neutral system glyphs for integrations."
+             width="1600" height="1066" loading="lazy" decoding="async">
+      </div>
+    </section>
 
-    <!-- FEATURES: Slab #3 (light) -->
-    <section class="section light">
-      <div class="container panel">
-        <div class="copy">
-          <h2>Scales without drift.</h2>
-          <p>Throughput at peak hours, consistent voice, and guardrails that actually hold.</p>
-        </div>
-        <img src="images/dashboard.webp"
-             alt="Dark analytics dashboard for voice bot with throughput and answer rate."
-             width="1600" height="1066" loading="lazy" decoding="async">
-      </div>
-    </section>
+    <!-- FEATURES: Slab #3 (light) -->
+    <section class="section light">
+      <div class="container panel">
+        <div class="copy">
+          <h2>Scales without drift.</h2>
+          <p>Throughout peak hours, consistent voice, and guardrails that actually hold.</p>
+        </div>
+        <img src="images/dashboard.webp"
+             alt="Dark analytics dashboard for voice bot with throughput and answer rate."
+             width="1600" height="1066" loading="lazy" decoding="async">
+      </div>
+    </section>
 
-    <!-- Sticky player lives once, globally -->
-    <div id="player" class="player" aria-live="polite">
-      <button id="playpause" class="icon" aria-label="Play/Pause" title="Play/Pause">⏯</button>
-      <span id="nowplaying" class="np">—</span>
-      <div class="seek"><input id="seekbar" type="range" min="0" max="100" value="0" aria-label="Seek"></div>
-      <button id="back15" class="icon" aria-label="Back 15s" title="Back 15s">↺15</button>
-      <button id="fwd15" class="icon" aria-label="Forward 15s" title="Forward 15s">15↻</button>
-      <select id="speed" aria-label="Playback speed">
-        <option>1.0×</option><option>1.25×</option><option>1.5×</option><option>1.75×</option><option>2.0×</option>
-      </select>
-      <audio id="audio" preload="none" crossorigin="anonymous"></audio>
-    </div>
+    <!-- PLANS -->
+    <section id="plans" class="section light" aria-labelledby="plans-title">
+      <div class="container">
+        <h2 id="plans-title">Plans that match your rollout</h2>
+        <p class="muted">Start now. Scale when you’re ready.</p>
 
-    <!-- PLANS (Slack-style, unchanged behavior) -->
-    <section id="plans" class="section light" aria-labelledby="plans-title">
-      <div class="container">
-        <h2 id="plans-title">Plans that match your rollout</h2>
-        <p class="muted">Start now. Scale when you’re ready.</p>
+        <div class="cards three">
+          <article class="card">
+            <h3>Starter</h3>
+            <p class="sub">Pilot a single bot in one channel.</p>
+            <ul>
+              <li>1 voice bot, 1 number</li>
+              <li>Basic transcripts & summaries</li>
+              <li>Email hand-offs</li>
+            </ul>
+            <div class="actions">
+              <a href="#contact" class="btn primary">Start free</a>
+              <a href="#compare" class="btn ghost">Compare plans</a>
+            </div>
+          </article>
 
-        <div class="cards three">
-          <article class="card">
-            <h3>Starter</h3>
-            <p class="sub">Pilot a single bot in one channel.</p>
-            <ul>
-              <li>1 voice bot, 1 number</li>
-              <li>Basic transcripts & summaries</li>
-              <li>Email hand-offs</li>
-            </ul>
-            <div class="actions">
-              <a href="#contact" class="btn primary">Start free</a>
-              <a href="#compare" class="btn ghost">Compare plans</a>
-            </div>
-          </article>
+          <article class="card accent">
+            <h3>Growth</h3>
+            <p class="sub">Multi-bot, CRM/webhook integration.</p>
+            <ul>
+              <li>Multiple bots & numbers</li>
+              <li>CRM/webhook sync</li>
+              <li>SLA support</li>
+            </ul>
+            <div class="actions">
+              <a href="#contact" class="btn primary">Talk to sales</a>
+              <a href="#compare" class="btn ghost">Compare plans</a>
+            </div>
+          </article>
 
-          <article class="card accent">
-            <h3>Growth</h3>
-            <p class="sub">Multi-bot, CRM/webhook integration.</p>
-            <ul>
-              <li>Multiple bots & numbers</li>
-              <li>CRM/webhook sync</li>
-              <li>SLA support</li>
-            </ul>
-            <div class="actions">
-              <a href="#contact" class="btn primary">Talk to sales</a>
-              <a href="#compare" class="btn ghost">Compare plans</a>
-            </div>
-          </article>
+          <article class="card">
+            <h3>Enterprise</h3>
+            <p class="sub">Security, compliance, and scale.</p>
+            <ul>
+              <li>SSO, audit trails</li>
+              <li>Dedicated success manager</li>
+              <li>Custom routing & guardrails</li>
+            </ul>
+            <div class="actions">
+              <a href="#contact" class="btn primary">Contact us</a>
+              <a href="#compare" class="btn ghost">Compare plans</a>
+            </div>
+          </article>
+        </div>
 
-          <article class="card">
-            <h3>Enterprise</h3>
-            <p class="sub">Security, compliance, and scale.</p>
-            <ul>
-              <li>SSO, audit trails</li>
-              <li>Dedicated success manager</li>
-              <li>Custom routing & guardrails</li>
-            </ul>
-            <div class="actions">
-              <a href="#contact" class="btn primary">Contact us</a>
-              <a href="#compare" class="btn ghost">Compare plans</a>
-            </div>
-          </article>
-        </div>
+        <div id="compare" class="compare">
+          <details>
+            <summary>See plan comparison</summary>
+            <table aria-label="Plan comparison">
+              <thead><tr><th>Feature</th><th>Starter</th><th>Growth</th><th>Enterprise</th></tr></thead>
+              <tbody>
+                <tr><td>Bots & numbers</td><td>1 / 1</td><td>Multi / Multi</td><td>Unlimited</td></tr>
+                <tr><td>Transcripts</td><td>Basic</td><td>Enhanced</td><td>Advanced + export</td></tr>
+                <tr><td>Integrations</td><td>Email</td><td>CRM/Webhooks</td><td>Custom</td></tr>
+                <tr><td>Support</td><td>Community</td><td>SLA</td><td>Dedicated</td></tr>
+                <tr><td>Compliance</td><td>—</td><td>—</td><td>SSO/Audit</td></tr>
+              </tbody>
+            </table>
+          </details>
+        </div>
+      </div>
+    </section>
 
-        <div id="compare" class="compare">
-          <details>
-            <summary>See plan comparison</summary>
-            <table aria-label="Plan comparison">
-              <thead><tr><th>Feature</th><th>Starter</th><th>Growth</th><th>Enterprise</th></tr></thead>
-              <tbody>
-                <tr><td>Bots & numbers</td><td>1 / 1</td><td>Multi / Multi</td><td>Unlimited</td></tr>
-                <tr><td>Transcripts</td><td>Basic</td><td>Enhanced</td><td>Advanced + export</td></tr>
-                <tr><td>Integrations</td><td>Email</td><td>CRM/Webhooks</td><td>Custom</td></tr>
-                <tr><td>Support</td><td>Community</td><td>SLA</td><td>Dedicated</td></tr>
-                <tr><td>Compliance</td><td>—</td><td>—</td><td>SSO/Audit</td></tr>
-              </tbody>
-            </table>
-          </details>
-        </div>
-      </div>
-    </section>
+    <!-- CONTACT -->
+    <section id="contact" class="section dark" aria-labelledby="contact-title">
+      <div class="container contact">
+        <h2 id="contact-title">Get started</h2>
+        <form class="contact-form" action="https://formspree.io/f/your-id" method="POST">
+          <label>Name<input name="name" required></label>
+          <label>Email<input name="email" type="email" required></label>
+          <label>Company<input name="company"></label>
+          <label>Message<textarea name="message" rows="4" placeholder="Tell us what you need automated."></textarea></label>
+          <button class="btn primary" type="submit">Request a callback</button>
+        </form>
+      </div>
+    </section>
 
-    <!-- CONTACT -->
-    <section id="contact" class="section dark" aria-labelledby="contact-title">
-      <div class="container contact">
-        <h2 id="contact-title">Get started</h2>
-        <form class="contact-form" action="https://formspree.io/f/your-id" method="POST">
-          <label>Name<input name="name" required></label>
-          <label>Email<input name="email" type="email" required></label>
-          <label>Company<input name="company"></label>
-          <label>Message<textarea name="message" rows="4" placeholder="Tell us what you need automated."></textarea></label>
-          <button class="btn primary" type="submit">Request a callback</button>
-        </form>
-      </div>
-    </section>
+    <!-- CTA FOOTER IMAGE -->
+    <section class="section dark cta-footer" aria-hidden="true">
+      <img src="images/cta.webp" alt="Minimal desk scene with friendly robot, mic puck, and waveform card."
+           width="1920" height="823" loading="lazy" decoding="async">
+    </section>
+  </main>
 
-    <!-- CTA FOOTER IMAGE -->
-    <section class="section dark cta-footer" aria-hidden="true">
-      <img src="images/cta.webp"
-           alt="Minimal desk scene with friendly robot, mic puck, and waveform card."
-           width="1920" height="823" loading="lazy" decoding="async">
-    </section>
-  </main>
-
-  <footer class="footer">
-    <nav class="foot-links">
-      <a href="#contact">Contact</a><span>•</span>
-      <a href="#" aria-disabled="true">Privacy</a><span>•</span>
-      <a href="#" aria-disabled="true">Terms</a>
-    </nav>
-    <p>© <span id="year"></span> Skybots. All rights reserved.</p>
-  </footer>
+  <footer class="footer">
+    <nav class="foot-links">
+      <a href="#contact">Contact</a><span>•</span>
+      <a href="#" aria-disabled="true">Privacy</a><span>•</span>
+      <a href="#" aria-disabled="true">Terms</a>
+    </nav>
+    <p>© <span id="year"></span> Skybots. All rights reserved.</p>
+  </footer>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,43 +1,44 @@
 :root{
-  --maxw:1240px; --gutter:clamp(16px,3vw,32px); --radius:18px;
-  --bg:#000; --fg:#fff; --muted:#6b6b70; --ink:#111; --paper:#fff;
-  --accent:#0A84FF; --shadow:0 10px 30px rgba(0,0,0,.25);
-  --slab:clamp(56px,10vw,120px);
-  --step0:clamp(15px,0.9vw + 10px,18px);
-  --step1:clamp(20px,1.6vw + 10px,26px);
-  --step2:clamp(28px,2.6vw + 12px,38px);
-  --step3:clamp(44px,4.2vw + 12px,64px);
-  --step4:clamp(64px,6.2vw + 16px,92px);
+  --maxw:1240px; --gutter:clamp(16px,3vw,32px); --radius:18px;
+  --bg:#000; --fg:#fff; --ink:#111; --paper:#fff;
+  --muted:#6b6b70; --accent:#0A84FF; --shadow:0 10px 30px rgba(0,0,0,.25);
+  --slab:clamp(56px,10vw,120px);
+  --step0:clamp(15px,0.9vw + 10px,18px);
+  --step1:clamp(20px,1.6vw + 10px,26px);
+  --step2:clamp(28px,2.6vw + 12px,38px);
+  --step3:clamp(44px,4.2vw + 12px,64px);
+  --step4:clamp(64px,6.2vw + 16px,92px);
 }
 
+/* Reset */
 *{box-sizing:border-box}
 html,body{margin:0;padding:0}
 body{
-  font:400 var(--step0)/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Inter,Arial,sans-serif;
-  color:var(--paper); background:var(--bg);
-  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  font:400 var(--step0)/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Inter,Arial,sans-serif;
+  color:var(--paper); background:var(--bg);
+  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
 }
 
-/* NAV — force dark, no accidental white */
+/* NAV — always dark and readable */
 .nav{
-  position:sticky; top:0; z-index:100;
-  display:flex; align-items:center; justify-content:space-between; gap:12px;
-  padding:12px var(--gutter);
-  background:rgba(17,17,17,.90); /* hard fallback */
-  -webkit-backdrop-filter:none; backdrop-filter:none; /* avoid frosted white */
-  border-bottom:1px solid rgba(255,255,255,.06);
+  position:sticky; top:0; z-index:100;
+  display:flex; align-items:center; justify-content:space-between; gap:12px;
+  padding:calc(10px + env(safe-area-inset-top)) var(--gutter) 10px var(--gutter);
+  background:#0b0b0c !important; /* kill any white/frosted bar */
+  color:#fff;
+  border-bottom:1px solid rgba(255,255,255,.06);
 }
-.nav a{color:#fff; text-decoration:none; padding:8px 10px; letter-spacing:-0.01em}
+.nav a:link, .nav a:visited{color:#fff; text-decoration:none; padding:8px 10px; letter-spacing:-0.01em}
 .nav .cta{background:#fff; color:#111; border-radius:999px; padding:8px 14px; font-weight:600}
 .brand{font-weight:700; letter-spacing:.2px}
 
-/* SECTIONS */
+/* Sections */
 .section{padding:var(--slab) 0}
 .section.light{background:#f5f5f7; color:#111}
 .section.dark{background:#000; color:#fff}
 .container{max-width:var(--maxw); margin:0 auto; padding:0 var(--gutter)}
 
-/* HERO */
+/* Hero */
 .hero{min-height:92vh; display:grid; place-items:center}
 .hero-grid{display:grid; grid-template-columns:1.05fr .95fr; gap:clamp(28px,4vw,56px); align-items:center}
 .hero h1{font-size:var(--step4); line-height:1.02; letter-spacing:-0.02em; margin:0 0 12px}
@@ -48,32 +49,26 @@ body{
 .btn.ghost{outline:1px solid #444}
 .hero-media img{width:100%; height:auto; border-radius:var(--radius); box-shadow:var(--shadow)}
 
-/* FEATURE PANELS */
+/* Feature panels */
 .panel{display:grid; grid-template-columns:1fr 1fr; align-items:center; gap:clamp(28px,4vw,56px)}
 .panel img{width:100%; height:auto; border-radius:var(--radius); box-shadow:var(--shadow)}
 .section.light .copy p{color:#333}
 
-/* INLINE DEMOS (left column in the light slab) */
+/* Inline demo list (left column, light slab) */
 .demos-inline{margin-top:18px}
-.demos-title{margin:0 0 10px; font-size:var(--step2)}
-.audio-grid.inline{display:grid; grid-template-columns:1fr; gap:12px}
-.section.light .audio-card.card{
-  background:#fff; color:#111; border:1px solid #e5e5ea; border-radius:14px; padding:14px
-}
-.section.light .audio-card h3{margin:0 0 6px; font-size:1.05rem; color:#111}
-.section.light .audio-card p{margin:.1rem 0 .6rem; color:#6b6b70}
-.section.light .audio-card button{
-  width:100%; padding:10px 12px; border-radius:10px; border:1px solid #d1d1d6; background:#f2f2f7; color:#111
-}
+.demos-title{margin:0 0 10px; font-size:var(--step2); color:#111}
+.demo-list{display:grid; grid-template-columns:1fr; gap:12px}
+.demo{display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:10px;
+      background:#fff; color:#111; border:1px solid #e5e5ea; border-radius:14px; padding:12px}
+.demo .play{width:38px; height:38px; border-radius:10px; border:1px solid #d1d1d6; background:#f2f2f7}
+.demo h4{margin:0; font-size:1.02rem}
+.demo .time{color:#6b6b70; font-variant-numeric:tabular-nums}
+.demo .seek{grid-column:1 / -1; width:100%}
+.skeleton.bar{height:78px; background:linear-gradient(90deg,#eee 25%,#f6f6f8 37%,#eee 63%);
+              background-size:400% 100%; animation:shimmer 1.2s infinite; border-radius:14px}
+@keyframes shimmer{0%{background-position:100% 0}100%{background-position:-100% 0}}
 
-/* STICKY PLAYER */
-.player{position:sticky; bottom:0; left:0; right:0; display:flex; align-items:center; gap:10px; padding:10px var(--gutter); background:rgba(10,10,10,.85)}
-.player .np{min-width:180px; opacity:.9}
-.player .seek{flex:1}
-.player input[type="range"]{width:100%}
-.icon{background:#1c1c1e; border:1px solid #333; color:#fff; border-radius:10px; padding:8px 10px}
-
-/* PLANS */
+/* Plans */
 .cards.three{display:grid; grid-template-columns:1fr 1fr 1fr; gap:20px}
 .card{background:#111; color:#fff; border:1px solid #1c1c1e; border-radius:16px; padding:24px}
 .card .sub{color:#c7c7cc; margin:.25rem 0 1rem}
@@ -85,7 +80,7 @@ body{
 .compare th,.compare td{border-bottom:1px solid #e5e5ea; padding:.6rem .4rem; text-align:left}
 .section.light .compare th,.section.light .compare td{color:#111}
 
-/* CONTACT + CTA FOOTER + FOOTER */
+/* Contact + CTA footer + Footer */
 .contact-form{display:grid; grid-template-columns:1fr 1fr; gap:14px}
 .contact-form label{display:grid; gap:6px; font-size:14px; color:#8e8e93}
 .contact-form input,.contact-form textarea{background:#0b0b0c; color:#fff; border:1px solid #2a2a2c; border-radius:10px; padding:12px}
@@ -97,10 +92,10 @@ body{
 
 /* Responsive */
 @media (max-width:980px){
-  .hero-grid{grid-template-columns:1fr}
-  .panel{grid-template-columns:1fr}
+  .hero-grid{grid-template-columns:1fr}
+  .panel{grid-template-columns:1fr}
 }
 @media (prefers-reduced-motion: reduce){
-  *{animation:none !important; transition:none !important}
+  *{animation:none !important; transition:none !important}
 }
 :focus-visible{outline:2px solid var(--accent); outline-offset:2px}


### PR DESCRIPTION
This PR updates the Skybots landing page to version 4.

- Forces a dark, readable navigation bar across all sections
- Moves the three audio demos into the first light slab as stacked bars in the left column and removes the sticky player
- Computes and displays the true durations of the demos from MP3 metadata
- Updates the copy in the third slab to "Throughout peak hours, consistent voice, and guardrails that actually hold"
- Keeps existing Slack-style plans and robot imagery

Ready to merge and deploy on GitHub Pages.